### PR TITLE
Propagate obs

### DIFF
--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -684,7 +684,9 @@ class MuData:
 
             # Drop columns that already exist in the individual modalities
             modobs.drop(np.intersect1d(tojoin, modobs.keys()), axis=1, inplace=True)
-            self.mod[k].obs = modobs.join(self.obs.loc[:, tojoin], how="left")
+            modobs = modobs.join(self.obs.loc[:, tojoin], how="left")
+            modobs.columns = modobs.columns.str.lstrip(f"{k}:")
+            self.mod[k].obs = modobs
             propagated_cols.extend(tojoin)
         # Propagated columns are no longer needed in the global df
         self.obs.drop(propagated_cols, axis=1, inplace=True)

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -685,7 +685,7 @@ class MuData:
             # Drop columns that already exist in the individual modalities
             modobs.drop(np.intersect1d(tojoin, modobs.keys()), axis=1, inplace=True)
             modobs = modobs.join(self.obs.loc[:, tojoin], how="left")
-            modobs.columns = modobs.columns.str.lstrip(f"{k}:")
+            modobs.columns = modobs.columns.str.replace(f"^{k}:", "", regex=True)
             self.mod[k].obs = modobs
             propagated_cols.extend(tojoin)
         # Propagated columns are no longer needed in the global df

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -661,7 +661,7 @@ class MuData:
         """
         return self.obs.index
 
-    def propagate_obs(self):
+    def propagate_obs(self, columns: List[str] = None):
         """
         Propagate global columns to all modalities
 
@@ -679,6 +679,8 @@ class MuData:
 
             tojoin = np.setdiff1d(global_keys, modcols)
             tojoin = [x for x in tojoin if not x.startswith(othermods)]
+            if columns:
+                tojoin = np.intersect1d(tojoin, columns)
 
             # Drop columns that already exist in the individual modalities
             modobs.drop(np.intersect1d(tojoin, modobs.keys()), axis=1, inplace=True)

--- a/tests/test_obs_var.py
+++ b/tests/test_obs_var.py
@@ -36,6 +36,17 @@ class TestMuData:
             "demo"
         ]
 
+    def test_obs_propagate(self, mdata, filepath_h5mu):
+        for m, mod in mdata.mod.items():
+            mod.obs["demo"] = m
+        mdata.obs["demo"] = "global"
+        mdata.obs["mod1:one"] = "one"
+        mdata.propagate_obs()
+        mdata.write(filepath_h5mu)
+        mdata_ = mudata.read(filepath_h5mu)
+        assert list(mdata_.mod["mod1"].obs.one == "one")
+        assert list([mdata.mod[k].obs.demo.values[0] == "global" for k in mdata_.mod])
+
     def test_var_global_columns(self, mdata, filepath_h5mu):
         for m, mod in mdata.mod.items():
             mod.var["demo"] = m


### PR DESCRIPTION
Implements the features from #2 

Tested with this:
```
import mudata as md
import anndata as ad
import numpy as np

mod1 = ad.AnnData(np.arange(0, 100, 0.1).reshape(-1, 10))
mod2 = ad.AnnData(np.arange(101, 2101, 1).reshape(-1, 20))
mods = {"mod1": mod1, "mod2": mod2}
# Make var_names different in different modalities
for m in ["mod1", "mod2"]:
    mods[m].var_names = [f"{m}_var{i}" for i in range(mods[m].n_vars)]
    mods[m].obs['common'] = 1
mod1.obs['individual1'] = 2
mod2.obs['individual2'] = 3
mdata = md.MuData(mods)

# Now add some global columns
mdata.obs['to_propagate'] = 1
mdata.obs['mod2:individualadded'] = 4
mdata.propagate_obs()

mdata.obs
mdata.mod['mod1'].obs
```

Has some minimal tests and docstring, please let me know what's missing.