### PR TITLE
Make update faster in some cases (#16)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,9 @@ Release notes
 v0.1.2
 ------
 
-There's `a new page describing the sharp bits <nuances.rst>`__.
+Updating a MuData object with :func:`mudata.MuData.update` is now much faster.
+
+This version also comes with an improved documentation, including `a new page describing the sharp bits <notebooks/nuances.ipynb>`__.
 
 v0.1.1
 ------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.abspath("../"))
 # -- Project information -----------------------------------------------------
 
 project = "mudata"
-copyright = "2020 - 2021, Danila Bredikhin"
+copyright = "2020 - 2022, Danila Bredikhin"
 author = "Danila Bredikhin"
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Say hello to MuData
 ===================
 
-``MuData`` is a format for annotated multimodal datasets. ``MuData`` is native to Python but provides cross-language functionality via HDF5-based ``.h5mu`` files.
+**MuData** is a format for annotated multimodal datasets. MuData is native to Python but provides cross-language functionality via HDF5-based ``.h5mu`` files.
 
 
 MuData objects as containers
@@ -14,12 +14,17 @@ MuData objects as containers
 	  atac: 10110 x 100001
 	  rna: 10110 x 10100
 
-``MuData`` objects enable multimodal information to be stored & accessed naturally, embrace `AnnData <https://github.com/theislab/anndata>`_ for the individual modalities, and can be serialized to ``.h5mu`` files. :doc:`Learn more about multimodal objects </io/mudata>` as well as :doc:`file formats for storing & sharing them </io/output>`. 
+MuData objects enable multimodal information to be stored & accessed naturally, embrace `AnnData <https://github.com/theislab/anndata>`_ for the individual modalities, and can be serialized to ``.h5mu`` files. :doc:`Learn more about multimodal objects </io/mudata>` as well as :doc:`file formats for storing & sharing them </io/output>`. 
+
+Natural interface
+-----------------
+
+MuData objects feature an AnnData-like interface and familiar concepts such as *observations* and *variables* for the two data dimensions. Get familiar with MuData in the :doc:`Quickstart tutorial </notebooks/quickstart_mudata>`.
 
 Handling MuData objects
 -----------------------
 
-A flagship framework for multimodal omics analysis — ``muon`` — has been built around the ``MuData`` format. Find more information on it `in its documentation <https://muon.readthedocs.io/en/latest/>`_ and `on the tutorials page <https://muon-tutorials.readthedocs.io/en/latest/>`_.
+A flagship framework for multimodal omics analysis — ``muon`` — has been built around the MuData format. Find more information on it `in its documentation <https://muon.readthedocs.io/en/latest/>`_ and `on the tutorials page <https://muon-tutorials.readthedocs.io/en/latest/>`_ as well as `in the corresponding publication <https://genomebiology.biomedcentral.com/articles/10.1186/s13059-021-02577-8>`_.
 
 
 .. toctree::
@@ -28,7 +33,7 @@ A flagship framework for multimodal omics analysis — ``muon`` — has been bui
    :caption: Getting started
 
    notebooks/quickstart_mudata.ipynb
-   nuances.rst
+   notebooks/nuances.ipynb
 
 .. toctree::
    :hidden:

--- a/docs/source/io/output.rst
+++ b/docs/source/io/output.rst
@@ -15,7 +15,7 @@ In order to save & share multimodal data, ``.h5mu`` file format has been designe
 .h5mu files
 -----------
 
-``.h5mu`` files are the default storage for ``MuData`` objects. These are HDF5 files with a standardised structure, which is similar to the one of ``.h5ad`` files where ``AnnData`` objects are stored. The most noticeable distinction is ``.mod`` group presence where individual modalities are stored — in the same way as they would be stored in the ``.h5ad`` files.
+``.h5mu`` files are the default storage for MuData objects. These are HDF5 files with a standardised structure, which is similar to the one of ``.h5ad`` files where AnnData objects are stored. The most noticeable distinction is ``.mod`` group presence where individual modalities are stored — in the same way as they would be stored in the ``.h5ad`` files.
 ::
 	mdata.write("mudata.h5mu")
 
@@ -46,3 +46,5 @@ Individual modalities in the ``.h5mu`` file are stored in exactly the same way a
 	mudata.write("mudata.h5mu/rna", adata)
 
 The function :func:`mudata.read` automatically decides based on the input if :func:`mudata.read_h5mu` or rather :func:`mudata.read_h5ad` should be called.
+
+Learn more about the on-disk format specification shared by MuData and AnnData `in the AnnData documentation <https://anndata.readthedocs.io/en/latest/fileformat-prose.html>`_.

--- a/docs/source/notebooks/nuances.ipynb
+++ b/docs/source/notebooks/nuances.ipynb
@@ -1,0 +1,493 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MuData nuances"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/scverse/mudata/blob/master/docs/source/notebooks/nuances.ipynb)\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/scverse/mudata/master?labpath=docs%2Fsource%2Fnotebooks%2Fnuances.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is *the sharp bits* page for ``mudata``, which provides information on the nuances when working with ``MuData`` objects."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, install and import `mudata` and other libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install mudata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mudata as md\n",
+    "from mudata import MuData, AnnData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prepare some simple [AnnData](https://anndata.readthedocs.io/) objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n, d1, d2, k = 1000, 100, 200, 10\n",
+    "\n",
+    "np.random.seed(1)\n",
+    "z = np.random.normal(loc=np.arange(k), scale=np.arange(k)*2, size=(n,k))\n",
+    "w1 = np.random.normal(size=(d1,k))\n",
+    "w2 = np.random.normal(size=(d2,k))\n",
+    "\n",
+    "mod1 = AnnData(X=np.dot(z, w1.T))\n",
+    "mod2 = AnnData(X=np.dot(z, w2.T))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variable names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> ***NB:** It is best to keep variable names unique across all the modalities. This will help to avoid ambiguity as well as performance of some functionality such as updating (see below).*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``MuData`` is designed with features (variables) being different in different modalities in mind. Hence their names should be unique and different between modalities. In other words, ``.var_names`` are checked for uniqueness across modalities.\n",
+    "\n",
+    "This behaviour ensures all the functions are easy to reason about. For instance, if there is a ``var_name`` that is present in both modalities, what happens during plotting a joint embedding from ``.obsm`` coloured by this ``var_name`` is not strictly defined."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nevertheless, ``MuData`` can accommodate modalities with duplicated ``.var_names``. For the typical workflows, we recommend renaming them manually or calling ``.var_names_make_unique()``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',\n",
+      "       ...\n",
+      "       '190', '191', '192', '193', '194', '195', '196', '197', '198', '199'],\n",
+      "      dtype='object', length=300)\n",
+      "Index(['mod1:0', 'mod1:1', 'mod1:2', 'mod1:3', 'mod1:4', 'mod1:5', 'mod1:6',\n",
+      "       'mod1:7', 'mod1:8', 'mod1:9',\n",
+      "       ...\n",
+      "       'mod2:190', 'mod2:191', 'mod2:192', 'mod2:193', 'mod2:194', 'mod2:195',\n",
+      "       'mod2:196', 'mod2:197', 'mod2:198', 'mod2:199'],\n",
+      "      dtype='object', length=300)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/mudata/_core/mudata.py:404: UserWarning: Cannot join columns with the same name because var_names are intersecting.\n",
+      "  warnings.warn(\n",
+      "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/mudata/_core/mudata.py:852: UserWarning: Modality names will be prepended to var_names since there are identical var_names in different modalities.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "mdata = MuData({\"mod1\": mod1, \"mod2\": mod2})\n",
+    "print(mdata.var_names)\n",
+    "mdata.var_names_make_unique()\n",
+    "print(mdata.var_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variable names in AnnData objects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the example above it is worth pointing out that `.var_names_make_unique()` is an in-place operation, just as [the same method](https://anndata.readthedocs.io/en/stable/anndata.AnnData.var_names_make_unique.html) is in `anndata`.\n",
+    "\n",
+    "Hence original AnnData objects' `.var_names` have also been modified:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['mod1:0', 'mod1:1', 'mod1:2', 'mod1:3', 'mod1:4', 'mod1:5', 'mod1:6',\n",
+       "       'mod1:7', 'mod1:8', 'mod1:9'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdata[\"mod1\"].var_names[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Update"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> ***NB:** If individual modalities are changed, updating the MuData object containing it might be required.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Modalities in ``MuData`` objects are full-featured ``AnnData`` objects. Hence they can be operated individually, and their ``MuData`` parent will have to be updated to fetch this information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Observations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Consider the following example: a new column has been added to a modality-specific metadata table:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mod1.obs[\"mod1_profiled\"] = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While `mdata` includes `mod1` as its first modality, it currently does not know about this change:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index([], dtype='object')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdata.obs.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`.update()` method will fetch these updates and propagate them to the global `.obs` table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['mod1:mod1_profiled'], dtype='object')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mod1:mod1_profiled</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   mod1:mod1_profiled\n",
+       "0                True\n",
+       "1                True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdata.update()\n",
+    "print(mdata.obs.columns)\n",
+    "mdata.obs.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As `MuData` objects are designed with shared observations by default, this annotation is automatically prefixed by the modality that originated this annotation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On the other hand, for variables, the default consideration is that they are unique to their modalities. This allows us to merge annotations across modalities, when possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mod1.var[\"assay\"] = \"A\"\n",
+    "mod2.var[\"assay\"] = \"B\"\n",
+    "\n",
+    "# Will fetch these values\n",
+    "mdata.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>assay</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>mod1:24</th>\n",
+       "      <td>A</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mod1:65</th>\n",
+       "      <td>A</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mod2:13</th>\n",
+       "      <td>B</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mod2:161</th>\n",
+       "      <td>B</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mod2:88</th>\n",
+       "      <td>B</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         assay\n",
+       "mod1:24      A\n",
+       "mod1:65      A\n",
+       "mod2:13      B\n",
+       "mod2:161     B\n",
+       "mod2:88      B"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.random.seed(10)\n",
+    "mdata.var.sample(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See how e.g. ``muon`` operates with ``MuData`` objects and enables access to modality-specific slots beyond just metadata [in the tutorials](https://muon-tutorials.readthedocs.io/en/latest/)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/notebooks/quickstart_mudata.ipynb
+++ b/docs/source/notebooks/quickstart_mudata.ipynb
@@ -11,7 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/scverse/mudata/blob/master/docs/source/notebooks/quickstart_mudata.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/scverse/mudata/blob/master/docs/source/notebooks/quickstart_mudata.ipynb)\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/scverse/mudata/master?labpath=docs%2Fsource%2Fnotebooks%2Fquickstart_mudata.ipynb)"
    ]
   },
   {
@@ -26,6 +28,15 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install mudata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -58,7 +69,7 @@
        "(1000, 100)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -84,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -93,7 +104,7 @@
        "AnnData object with n_obs × n_vars = 1000 × 100"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -116,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -125,7 +136,7 @@
        "AnnData object with n_obs × n_vars = 1000 × 50"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -150,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +179,7 @@
        "    B:\t1000 x 50"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -214,7 +225,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -232,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -257,7 +268,7 @@
        "       False, False, False, False, False, False])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -301,7 +312,7 @@
        "{'adata': True}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -320,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -384,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -526,27 +537,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre>MuData object with n_obs × n_vars = 1000 × 150 backed at &#x27;/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_gdvcgvu3.h5mu&#x27;\n",
+       "<pre>MuData object with n_obs × n_vars = 1000 × 150 backed at &#x27;/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_m8own7bb.h5mu&#x27;\n",
        "  2 modalities\n",
        "    A:\t1000 x 100\n",
        "      uns:\t&#x27;misc&#x27;\n",
        "    B:\t1000 x 50</pre>"
       ],
       "text/plain": [
-       "MuData object with n_obs × n_vars = 1000 × 150 backed at '/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_gdvcgvu3.h5mu'\n",
+       "MuData object with n_obs × n_vars = 1000 × 150 backed at '/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_m8own7bb.h5mu'\n",
        "  2 modalities\n",
        "    A:\t1000 x 100\n",
        "      uns:\t'misc'\n",
        "    B:\t1000 x 50"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -571,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -580,7 +591,7 @@
        "True"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -598,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -679,21 +690,21 @@
        "details[open] > .summary-mod::before {\n",
        "  content: '○';\n",
        "}\n",
-       "</style><span>MuData object <span class='hl-dim'>1000 obs &times; 150 var in 2 modalities</span></span><br>&#8627; <span>backed at <span class='hl-file'>/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_gdvcgvu3.h5mu</span></span><br><details><summary><div class='title title-attr'>Metadata</div><span class='hl-dim'>.obs</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No metadata</span></details><details><summary><div class='title title-attr'>Embeddings & mappings</div><span class='hl-dim'>.obsm</span><span class='hl-size'>2 elements</span></summary><div><table><tr>\n",
+       "</style><span>MuData object <span class='hl-dim'>1000 obs &times; 150 var in 2 modalities</span></span><br>&#8627; <span>backed at <span class='hl-file'>/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_m8own7bb.h5mu</span></span><br><details><summary><div class='title title-attr'>Metadata</div><span class='hl-dim'>.obs</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No metadata</span></details><details><summary><div class='title title-attr'>Embeddings & mappings</div><span class='hl-dim'>.obsm</span><span class='hl-size'>2 elements</span></summary><div><table><tr>\n",
        "                                       <td class='col-index'>A</td>  <td class='hl-types'>bool</td>  <td><span class='hl-import'>numpy.</span>ndarray</td>  <td class='hl-dims'></td>\n",
        "                                   </tr>\n",
        "<tr>\n",
        "                                       <td class='col-index'>B</td>  <td class='hl-types'>bool</td>  <td><span class='hl-import'>numpy.</span>ndarray</td>  <td class='hl-dims'></td>\n",
-       "                                   </tr></table></div></details><details><summary><div class='title title-attr'>Distances</div><span class='hl-dim'>.obsp</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No distances</span></details><div class='block-mod'><div><details><summary class='summary-mod'><div class='title title-mod'>A</div><span class='hl-dim'>1000 &times 100</span></summary><span>AnnData object <span class='hl-dim'>1000 obs &times; 100 var</span></span><br>&#8627; <span>backed at <span class='hl-file'>/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_gdvcgvu3.h5mu</span></span><br><div class='title title-attr'>Matrix</div><span class='hl-dim'>.X</span><div>\n",
+       "                                   </tr></table></div></details><details><summary><div class='title title-attr'>Distances</div><span class='hl-dim'>.obsp</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No distances</span></details><div class='block-mod'><div><details><summary class='summary-mod'><div class='title title-mod'>A</div><span class='hl-dim'>1000 &times 100</span></summary><span>AnnData object <span class='hl-dim'>1000 obs &times; 100 var</span></span><br>&#8627; <span>backed at <span class='hl-file'>/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_m8own7bb.h5mu</span></span><br><div class='title title-attr'>Matrix</div><span class='hl-dim'>.X</span><div>\n",
        "            <span class='hl-types'>float32</span> <span>&nbsp;&nbsp;&nbsp;<span class='hl-import'>h5py._hl.dataset.</span>Dataset</span>\n",
        "         </table></div><details><summary><div class='title title-attr'>Layers</div><span class='hl-dim'>.layers</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No layers</span></details><details><summary><div class='title title-attr'>Metadata</div><span class='hl-dim'>.obs</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No metadata</span></details><details><summary><div class='title title-attr'>Embeddings</div><span class='hl-dim'>.obsm</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No embeddings</span></details><details><summary><div class='title title-attr'>Distances</div><span class='hl-dim'>.obsp</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No distances</span></details><details><summary><div class='title title-attr'>Miscellaneous</div><span class='hl-dim'>.uns</span><span class='hl-size'>1 elements</span></summary><div><table><tr>\n",
        "                                <td class='col-index'>misc</td>  <td><span class='hl-import'></span>dict</td>  <td class='hl-dims'>1 element</td>  <td class='hl-values'>adata: True</td>\n",
-       "                            </tr></table></div></details></details></div></div><div class='block-mod'><div><details><summary class='summary-mod'><div class='title title-mod'>B</div><span class='hl-dim'>1000 &times 50</span></summary><span>AnnData object <span class='hl-dim'>1000 obs &times; 50 var</span></span><br>&#8627; <span>backed at <span class='hl-file'>/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_gdvcgvu3.h5mu</span></span><br><div class='title title-attr'>Matrix</div><span class='hl-dim'>.X</span><div>\n",
+       "                            </tr></table></div></details></details></div></div><div class='block-mod'><div><details><summary class='summary-mod'><div class='title title-mod'>B</div><span class='hl-dim'>1000 &times 50</span></summary><span>AnnData object <span class='hl-dim'>1000 obs &times; 50 var</span></span><br>&#8627; <span>backed at <span class='hl-file'>/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_m8own7bb.h5mu</span></span><br><div class='title title-attr'>Matrix</div><span class='hl-dim'>.X</span><div>\n",
        "            <span class='hl-types'>float32</span> <span>&nbsp;&nbsp;&nbsp;<span class='hl-import'>h5py._hl.dataset.</span>Dataset</span>\n",
        "         </table></div><details><summary><div class='title title-attr'>Layers</div><span class='hl-dim'>.layers</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No layers</span></details><details><summary><div class='title title-attr'>Metadata</div><span class='hl-dim'>.obs</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No metadata</span></details><details><summary><div class='title title-attr'>Embeddings</div><span class='hl-dim'>.obsm</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No embeddings</span></details><details><summary><div class='title title-attr'>Distances</div><span class='hl-dim'>.obsp</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No distances</span></details><details><summary><div class='title title-attr'>Miscellaneous</div><span class='hl-dim'>.uns</span><span class='hl-size'>0 elements</span></summary><span class='hl-empty'>No miscellaneous</span></details></details></div></div><br/>"
       ],
       "text/plain": [
-       "MuData object with n_obs × n_vars = 1000 × 150 backed at '/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_gdvcgvu3.h5mu'\n",
+       "MuData object with n_obs × n_vars = 1000 × 150 backed at '/var/folders/xt/tvy3s7w17vn1b700k_351pz00000gp/T/muon_getting_started_m8own7bb.h5mu'\n",
        "  2 modalities\n",
        "    A:\t1000 x 100\n",
        "      uns:\t'misc'\n",
@@ -725,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -734,7 +745,7 @@
        "(1000, 150)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -753,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -821,7 +832,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/requirements.txt
+++ b/docs/source/notebooks/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+anndata
+mudata

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -379,13 +379,17 @@ class MuData:
             for m, mod in self.mod.items():
                 if m in self._mod_index:
                     if attr in self._mod_index[m]:
-                        attr_names_maybe_changed = attr_names_maybe_changed or not getattr(self.mod[m], attr).index.equals(self._mod_index[m][attr])
+                        attr_names_maybe_changed = attr_names_maybe_changed or not getattr(
+                            self.mod[m], attr
+                        ).index.equals(self._mod_index[m][attr])
 
         attr_duplicated = self._check_duplicated_attr_names(attr)
         attr_intersecting = self._check_intersecting_attr_names(attr)
 
         if attr_duplicated:
-            warnings.warn(f"{attr}_names are not unique. To make them unique, call `.{attr}_names_make_unique`.")
+            warnings.warn(
+                f"{attr}_names are not unique. To make them unique, call `.{attr}_names_make_unique`."
+            )
 
         # Check if the are same obs_names/var_names in different modalities
         # If there are, join_common=True request can not be satisfied
@@ -439,14 +443,16 @@ class MuData:
                 columns_common = reduce(
                     np.intersect1d, [getattr(self.mod[mod], attr).columns for mod in self.mod]
                 )
-                data_global = data_global.loc[:, [c not in columns_common for c in data_global.columns]]
+                data_global = data_global.loc[
+                    :, [c not in columns_common for c in data_global.columns]
+                ]
 
                 # We checked above that attr_names are guaranteed to be unique and thus are safe to be used for joins
                 data_mod = pd.concat(
                     [getattr(a, attr).drop(columns_common, axis=1) for m, a in self.mod.items()],
                     join="outer",
                     axis=axis,
-                    sort = False,
+                    sort=False,
                 )
                 data_common = pd.concat(
                     [getattr(a, attr)[columns_common] for m, a in self.mod.items()],
@@ -455,18 +461,20 @@ class MuData:
                     sort=False,
                 )
                 data_mod = data_mod.join(data_common, how="left", sort=False)
-            else: 
+            else:
                 data_mod = pd.concat(
                     [getattr(a, attr) for m, a in self.mod.items()],
                     join="outer",
                     axis=axis,
-                    sort = False,
+                    sort=False,
                 )
 
             # this occurs when join_common=True and we already have a global data frame, e.g. after reading from HDF5
             if join_common:
                 sharedcols = data_mod.columns.intersection(data_global.columns)
-                data_global.rename(columns={col: f"global:{col}" for col in sharedcols}, inplace=True)
+                data_global.rename(
+                    columns={col: f"global:{col}" for col in sharedcols}, inplace=True
+                )
 
             # TODO: is using an attrmap here has any benefit when no duplicates or intersections?
 
@@ -485,7 +493,7 @@ class MuData:
                             f"Column {col} was present in {attr} but is also a common column in all modalities, and their contents differ. {attr}.{col} was renamed to {attr}.{gcol}."
                         )
 
-            # Add data from global .obs/.var columns 
+            # Add data from global .obs/.var columns
             # This might reduce the size of .obs/.var if observations/variables were removed
             setattr(
                 # Original index is present in data_global
@@ -501,7 +509,7 @@ class MuData:
             for m in self.mod.keys():
                 mdict[m] = np.zeros(data_mod.shape[0])
                 mod_size = getattr(self.mod[m], attr).shape[0]
-                mdict[m][incr:(incr+mod_size)] = np.arange(mod_size) + 1
+                mdict[m][incr : (incr + mod_size)] = np.arange(mod_size) + 1
                 incr += mod_size
 
         #
@@ -513,7 +521,9 @@ class MuData:
                 columns_common = reduce(
                     np.intersect1d, [getattr(self.mod[mod], attr).columns for mod in self.mod]
                 )
-                data_global = data_global.loc[:, [c not in columns_common for c in data_global.columns]]
+                data_global = data_global.loc[
+                    :, [c not in columns_common for c in data_global.columns]
+                ]
                 dfs = [
                     _make_index_unique(
                         getattr(a, attr)
@@ -533,7 +543,10 @@ class MuData:
                 )
 
                 data_common = pd.concat(
-                    [_make_index_unique(getattr(a, attr)[columns_common]) for m, a in self.mod.items()],
+                    [
+                        _make_index_unique(getattr(a, attr)[columns_common])
+                        for m, a in self.mod.items()
+                    ],
                     join="outer",
                     axis=0,
                     sort=False,
@@ -576,7 +589,9 @@ class MuData:
             # this occurs when join_common=True and we already have a global data frame, e.g. after reading from HDF5
             if join_common:
                 sharedcols = data_mod.columns.intersection(data_global.columns)
-                data_global.rename(columns={col: f"global:{col}" for col in sharedcols}, inplace=True)
+                data_global.rename(
+                    columns={col: f"global:{col}" for col in sharedcols}, inplace=True
+                )
 
             data_mod = _restore_index(data_mod)
             data_mod.index.set_names(rowcol, inplace=True)

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -506,16 +506,6 @@ class MuData:
             if len(data_global) > 0:
                 data_mod = data_mod.join(data_global, how="left", sort=False)
 
-            if join_common:
-                for col in sharedcols:
-                    gcol = f"global:{col}"
-                    if data_mod[col].equals(data_mod[gcol]):
-                        data_mod.drop(columns=gcol, inplace=True)
-                    else:
-                        warnings.warn(
-                            f"Column {col} was present in {attr} but is also a common column in all modalities, and their contents differ. {attr}.{col} was renamed to {attr}.{gcol}."
-                        )
-
         #
         # General case: with duplicates and/or intersections
         #
@@ -621,15 +611,15 @@ class MuData:
             data_mod.reset_index(level=list(range(1, data_mod.index.nlevels)), inplace=True)
             data_mod.index.set_names(None, inplace=True)
 
-            if join_common:
-                for col in sharedcols:
-                    gcol = f"global:{col}"
-                    if data_mod[col].equals(data_mod[gcol]):
-                        data_mod.drop(columns=gcol, inplace=True)
-                    else:
-                        warnings.warn(
-                            f"Column {col} was present in {attr} but is also a common column in all modalities, and their contents differ. {attr}.{col} was renamed to {attr}.{gcol}."
-                        )
+        if join_common:
+            for col in sharedcols:
+                gcol = f"global:{col}"
+                if data_mod[col].equals(data_mod[gcol]):
+                    data_mod.drop(columns=gcol, inplace=True)
+                else:
+                    warnings.warn(
+                        f"Column {col} was present in {attr} but is also a common column in all modalities, and their contents differ. {attr}.{col} was renamed to {attr}.{gcol}."
+                    )
 
         # get adata positions and remove columns from the data frame
         mdict = dict()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -49,12 +49,12 @@ class TestMuData:
         mdata = MuData(modalities)
         mdata.update()
 
-        # Observations are the same across modalities
-        # hence /mod/mod1/obs/mod -> /obs/mod1:mod
-        assert f"{m}:mod" in mdata.obs.columns
         # Variables are different across modalities
         assert "mod" in mdata.var.columns
         for m, mod in modalities.items():
+            # Observations are the same across modalities
+            # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+            assert f"{m}:mod" in mdata.obs.columns
             # Columns are intact in individual modalities
             assert "mod" in mod.obs.columns
             assert "mod" in mod.var.columns
@@ -71,12 +71,12 @@ class TestMuData:
         mdata = MuData(modalities)
         mdata.update()
 
-        # Observations are the same across modalities
-        # hence /mod/mod1/obs/mod -> /obs/mod1:mod
-        assert f"{m}:mod" in mdata.obs.columns
         # Variables are different across modalities
         assert "mod" in mdata.var.columns
         for m, mod in modalities.items():
+            # Observations are the same across modalities
+            # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+            assert f"{m}:mod" in mdata.obs.columns
             # Columns are intact in individual modalities
             assert "mod" in mod.obs.columns
             assert "mod" in mod.var.columns
@@ -94,10 +94,10 @@ class TestMuData:
         mdata = MuData(modalities)
         mdata.update()
 
-        # Observations are the same across modalities
-        # hence /mod/mod1/obs/mod -> /obs/mod1:mod
-        assert f"{m}:mod" in mdata.obs.columns
         for m, mod in modalities.items():
+            # Observations are the same across modalities
+            # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+            assert f"{m}:mod" in mdata.obs.columns
             # Variables are intersecting
             # so they won't be merged
             assert f"{m}:mod" in mdata.var.columns

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -8,9 +8,9 @@ from mudata import MuData
 
 @pytest.fixture()
 def mdata():
+    np.random.seed(100)
     mod1 = AnnData(X=np.random.normal(size=1000).reshape(-1, 10))
     mod2 = AnnData(X=np.random.normal(size=1000).reshape(-1, 10))
-    np.random.seed(100)
     batches = np.random.choice(["a", "b", "c"], size=100, replace=True)
     mods = {"mod1": mod1, "mod2": mod2}
     # Make var_names different in different modalities
@@ -21,18 +21,122 @@ def mdata():
     mdata.obs["batch"] = batches
     yield mdata
 
+@pytest.fixture()
+def modalities():
+    n_mod = 3
+    mods = dict()
+    np.random.seed(100)
+    for i in range(n_mod):
+        i1 = i + 1
+        m = f"mod{i1}"
+        mods[m] = AnnData(X=np.random.normal(size=1000*i1).reshape(-1, 10*i1))
+        mods[m].obs["mod"] = m
+        mods[m].var["mod"] = m
+    return mods
 
 @pytest.mark.usefixtures("filepath_h5mu")
 class TestMuData:
+    def test_update_simple(self, modalities):
+        """
+        Update should work when
+        - obs_names are the same across modalities,
+        - var_names are unique to each modality
+        """
+        for m, mod in modalities.items():
+            mod.var_names = [f"{m}_var{j}" for j in range(mod.n_vars)]
+        mdata = MuData(modalities)
+        mdata.update()
+        
+        # Observations are the same across modalities
+        # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+        assert f"{m}:mod" in mdata.obs.columns
+        # Variables are different across modalities
+        assert "mod" in mdata.var.columns
+        for m, mod in modalities.items():
+            # Columns are intact in individual modalities
+            assert "mod" in mod.obs.columns
+            assert "mod" in mod.var.columns
+
+    def test_update_duplicates(self, modalities):
+        """
+        Update should work when
+        - obs_names are the same across modalities,
+        - there are duplicated var_names, which are not intersecting
+          between modalities
+        """
+        for m, mod in modalities.items():
+            mod.var_names = [f"{m}_var{j // 2}" for j in range(mod.n_vars)]
+        mdata = MuData(modalities)
+        mdata.update()
+        
+        # Observations are the same across modalities
+        # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+        assert f"{m}:mod" in mdata.obs.columns
+        # Variables are different across modalities
+        assert "mod" in mdata.var.columns
+        for m, mod in modalities.items():
+            # Columns are intact in individual modalities
+            assert "mod" in mod.obs.columns
+            assert "mod" in mod.var.columns
+
+    def test_update_intersecting(self, modalities):
+        """
+        Update should work when
+        - obs_names are the same across modalities,
+        - there are intersecting var_names, 
+          which are unique in each modality
+        """
+        for m, mod in modalities.items():
+            # [mod1] var0, mod1_var1, mod1_var2, ...; [mod2] var0, mod2_var1, mod2_var2, ...
+            mod.var_names = [f"{m}_var{j}" if j != 0 else f"var_{j}" for j in range(mod.n_vars)]
+        mdata = MuData(modalities)
+        mdata.update()
+        
+        # Observations are the same across modalities
+        # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+        assert f"{m}:mod" in mdata.obs.columns
+        for m, mod in modalities.items():
+            # Variables are intersecting
+            # so they won't be merged
+            assert f"{m}:mod" in mdata.var.columns
+            # Columns are intact in individual modalities
+            assert "mod" in mod.obs.columns
+            assert "mod" in mod.var.columns
+
+
     def test_update_after_filter_obs_adata(self, mdata, filepath_h5mu):
         """
         Check for muon issue #44.
         """
-        # Replicate in-place filterin in muon:
+        # Replicate in-place filtering in muon:
         # mu.pp.filter_obs(mdata['mod1'], 'min_count', lambda x: (x < -2))
         mdata.mod["mod1"] = mdata["mod1"][mdata["mod1"].obs["min_count"] < -2].copy()
         mdata.update()
         assert mdata.obs["batch"].isna().sum() == 0
+
+
+# @pytest.mark.usefixtures("filepath_h5mu")
+# class TestMuDataSameVars:
+#     def test_update_simple(self, modalities):
+#         """
+#         Update should work when
+#         - obs_names are the same across modalities,
+#         - var_names are unique to each modality
+#         """
+#         for m, mod in modalities.items():
+#             mod.var_names = [f"{m}var_{j}" for j in range(mod.n_vars)]
+#         mdata = MuData(modalities, axis=0)
+#         mdata.update()
+        
+#         # Observations are the same across modalities
+#         # hence /mod/mod1/obs/mod -> /obs/mod1:mod
+#         assert f"{m}:mod" in mdata.obs.columns
+#         # Variables are different across modalities
+#         assert "mod" in mdata.var.columns
+#         for m, mod in modalities.items():
+#             # Columns are intact in individual modalities
+#             assert "mod" in mod.obs.columns
+#             assert "mod" in mod.var.columns
 
 
 if __name__ == "__main__":

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -21,6 +21,7 @@ def mdata():
     mdata.obs["batch"] = batches
     yield mdata
 
+
 @pytest.fixture()
 def modalities():
     n_mod = 3
@@ -29,10 +30,11 @@ def modalities():
     for i in range(n_mod):
         i1 = i + 1
         m = f"mod{i1}"
-        mods[m] = AnnData(X=np.random.normal(size=1000*i1).reshape(-1, 10*i1))
+        mods[m] = AnnData(X=np.random.normal(size=1000 * i1).reshape(-1, 10 * i1))
         mods[m].obs["mod"] = m
         mods[m].var["mod"] = m
     return mods
+
 
 @pytest.mark.usefixtures("filepath_h5mu")
 class TestMuData:
@@ -46,7 +48,7 @@ class TestMuData:
             mod.var_names = [f"{m}_var{j}" for j in range(mod.n_vars)]
         mdata = MuData(modalities)
         mdata.update()
-        
+
         # Observations are the same across modalities
         # hence /mod/mod1/obs/mod -> /obs/mod1:mod
         assert f"{m}:mod" in mdata.obs.columns
@@ -68,7 +70,7 @@ class TestMuData:
             mod.var_names = [f"{m}_var{j // 2}" for j in range(mod.n_vars)]
         mdata = MuData(modalities)
         mdata.update()
-        
+
         # Observations are the same across modalities
         # hence /mod/mod1/obs/mod -> /obs/mod1:mod
         assert f"{m}:mod" in mdata.obs.columns
@@ -83,7 +85,7 @@ class TestMuData:
         """
         Update should work when
         - obs_names are the same across modalities,
-        - there are intersecting var_names, 
+        - there are intersecting var_names,
           which are unique in each modality
         """
         for m, mod in modalities.items():
@@ -91,7 +93,7 @@ class TestMuData:
             mod.var_names = [f"{m}_var{j}" if j != 0 else f"var_{j}" for j in range(mod.n_vars)]
         mdata = MuData(modalities)
         mdata.update()
-        
+
         # Observations are the same across modalities
         # hence /mod/mod1/obs/mod -> /obs/mod1:mod
         assert f"{m}:mod" in mdata.obs.columns
@@ -102,7 +104,6 @@ class TestMuData:
             # Columns are intact in individual modalities
             assert "mod" in mod.obs.columns
             assert "mod" in mod.var.columns
-
 
     def test_update_after_filter_obs_adata(self, mdata, filepath_h5mu):
         """
@@ -127,7 +128,7 @@ class TestMuData:
 #             mod.var_names = [f"{m}var_{j}" for j in range(mod.n_vars)]
 #         mdata = MuData(modalities, axis=0)
 #         mdata.update()
-        
+
 #         # Observations are the same across modalities
 #         # hence /mod/mod1/obs/mod -> /obs/mod1:mod
 #         assert f"{m}:mod" in mdata.obs.columns

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -7,23 +7,48 @@ from mudata import MuData
 
 
 @pytest.fixture()
-def mdata():
+def mdata(request, obs_n, obs_across, obs_mod):
+    # Generate unique, intersecting, and joint observations by default
     np.random.seed(100)
     mod1 = AnnData(X=np.random.normal(size=1000).reshape(-1, 10))
     mod2 = AnnData(X=np.random.normal(size=1000).reshape(-1, 10))
-    batches = np.random.choice(["a", "b", "c"], size=100, replace=True)
+
     mods = {"mod1": mod1, "mod2": mod2}
     # Make var_names different in different modalities
     for m in ["mod1", "mod2"]:
+        mods[m].obs_names = [f"obs{i}" for i in range(mods[m].n_obs)]
         mods[m].var_names = [f"{m}_var{i}" for i in range(mods[m].n_vars)]
         mods[m].obs["min_count"] = mods[m].X.min(axis=1)
+
+    if obs_n:
+        if obs_n == "disjoint":
+            mod2_which_obs = np.random.choice(
+                mods["mod2"].obs_names, size=mods["mod2"].n_obs // 2, replace=False
+            )
+            mods["mod2"] = mods["mod2"][mod2_which_obs].copy()
+
+    if obs_across:
+        if obs_across != "intersecting":
+            raise NotImplementedError("Tests for non-intersecting obs_names are not implemented")
+
+    if obs_mod:
+        if obs_mod == "duplicated":
+            for m in ["mod1", "mod2"]:
+                # Index does not support mutable operations
+                obs_names = mods[m].obs_names.values.copy()
+                obs_names[1] = obs_names[0]
+                mods[m].obs_names = obs_names
+
     mdata = MuData(mods)
+
+    batches = np.random.choice(["a", "b", "c"], size=mdata.shape[0], replace=True)
     mdata.obs["batch"] = batches
+
     yield mdata
 
 
 @pytest.fixture()
-def modalities():
+def modalities(request, obs_n, obs_across, obs_mod):
     n_mod = 3
     mods = dict()
     np.random.seed(100)
@@ -33,11 +58,34 @@ def modalities():
         mods[m] = AnnData(X=np.random.normal(size=1000 * i1).reshape(-1, 10 * i1))
         mods[m].obs["mod"] = m
         mods[m].var["mod"] = m
+
+    if obs_n:
+        if obs_n == "disjoint":
+            mod2_which_obs = np.random.choice(
+                mods["mod2"].obs_names, size=mods["mod2"].n_obs // 2, replace=False
+            )
+            mods["mod2"] = mods["mod2"][mod2_which_obs].copy()
+
+    if obs_across:
+        if obs_across != "intersecting":
+            raise NotImplementedError("Tests for non-intersecting obs_names are not implemented")
+
+    if obs_mod:
+        if obs_mod == "duplicated":
+            for m in ["mod1", "mod2"]:
+                # Index does not support mutable operations
+                obs_names = mods[m].obs_names.values.copy()
+                obs_names[1] = obs_names[0]
+                mods[m].obs_names = obs_names
+
     return mods
 
 
 @pytest.mark.usefixtures("filepath_h5mu")
 class TestMuData:
+    @pytest.mark.parametrize("obs_mod", ["unique", "duplicated"])
+    @pytest.mark.parametrize("obs_across", ["intersecting"])
+    @pytest.mark.parametrize("obs_n", ["joint", "disjoint"])
     def test_update_simple(self, modalities):
         """
         Update should work when
@@ -57,8 +105,13 @@ class TestMuData:
             assert f"{m}:mod" in mdata.obs.columns
             # Columns are intact in individual modalities
             assert "mod" in mod.obs.columns
+            assert all(mod.obs["mod"] == m)
             assert "mod" in mod.var.columns
+            assert all(mod.var["mod"] == m)
 
+    @pytest.mark.parametrize("obs_mod", ["unique", "duplicated"])
+    @pytest.mark.parametrize("obs_across", ["intersecting"])
+    @pytest.mark.parametrize("obs_n", ["joint", "disjoint"])
     def test_update_duplicates(self, modalities):
         """
         Update should work when
@@ -79,8 +132,13 @@ class TestMuData:
             assert f"{m}:mod" in mdata.obs.columns
             # Columns are intact in individual modalities
             assert "mod" in mod.obs.columns
+            assert all(mod.obs["mod"] == m)
             assert "mod" in mod.var.columns
+            assert all(mod.var["mod"] == m)
 
+    @pytest.mark.parametrize("obs_mod", ["unique", "duplicated"])
+    @pytest.mark.parametrize("obs_across", ["intersecting"])
+    @pytest.mark.parametrize("obs_n", ["joint", "disjoint"])
     def test_update_intersecting(self, modalities):
         """
         Update should work when
@@ -103,8 +161,13 @@ class TestMuData:
             assert f"{m}:mod" in mdata.var.columns
             # Columns are intact in individual modalities
             assert "mod" in mod.obs.columns
+            assert all(mod.obs["mod"] == m)
             assert "mod" in mod.var.columns
+            assert all(mod.var["mod"] == m)
 
+    @pytest.mark.parametrize("obs_mod", ["unique", "duplicated"])
+    @pytest.mark.parametrize("obs_across", ["intersecting"])
+    @pytest.mark.parametrize("obs_n", ["joint", "disjoint"])
     def test_update_after_filter_obs_adata(self, mdata, filepath_h5mu):
         """
         Check for muon issue #44.


### PR DESCRIPTION
Addresses #16.

When attr_names (typically var_names) are unique and not intersecting between modalities, this should greatly improve the speed of the `mdata.update()`.
