### PR TITLE
Make sure `mdata.uns` is also printed

### DIFF
--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -1200,7 +1200,7 @@ class MuData:
         backed_at = f" backed at {str(self.filename)!r}" if self.isbacked else ""
         view_of = "View of " if self.is_view else ""
         descr = f"{view_of}MuData object with n_obs × n_vars = {n_obs} × {n_vars}{backed_at}"
-        for attr in ["obs", "var", "obsm", "varm", "obsp", "varp"]:
+        for attr in ["obs", "var", "uns", "obsm", "varm", "obsp", "varp"]:
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 keys = list(getattr(self, attr).keys())
                 if len(keys) > 0:


### PR DESCRIPTION
Right now, the `.uns` slot in a MuData object is not being printed, despite one being there:

```python
>>> result
MuData object with n_obs × n_vars = 134629 × 5605
  var:  'gene_symbol', 'feature_types', 'genome'
  1 modality
    rna:        134629 x 5594
      var:      'gene_symbol', 'feature_types', 'genome'

>>> result.uns
{'metrics_cellranger':    Category      Library Type           Grouped By Group Name                        Metric Name         Metric Value
0     Cells  Antibody Capture                  NaN        NaN     Antibody reads usable per cell                  0.9
1     Cells  Antibody Capture                  NaN        NaN                              Cells                3,694
2     Cells  Antibody Capture                  NaN        NaN         Median UMI counts per cell                 0.56
3     Cells   Gene Expression                  NaN        NaN                              Cells                3,694
4     Cells   Gene Expression                  NaN        NaN  Confidently mapped reads in cells               0.8217
...
[68 rows x 6 columns]}
```

This PR allows the `.uns` to be printed as well.

Credits to @DriesSchaumont for spotting this issue!