### PR TITLE
Fixes for MuData 0.3 release

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/mudata/badge/?version=latest)](http://mudata.readthedocs.io/)
 [![PyPi version](https://img.shields.io/pypi/v/mudata)](https://pypi.org/project/mudata)
-[![Powered by NumFOCUS][https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A]][https://numfocus.org]
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 # MuData – multimodal data
 

--- a/docs/source/io/input.rst
+++ b/docs/source/io/input.rst
@@ -46,3 +46,23 @@ Omics data
 When data fromats specific to genomics are of interest, specialised readers can be found in analysis frameworks such as `muon <https://muon.readthedocs.io/>`_. These functions, including the ones for Cell Ranger count matrices as well as Snap files, `are described here <https://muon.readthedocs.io/en/latest/io/input.html>`_.
 
 
+Remote storage
+--------------
+
+MuData objects can be read and cached from remote locations including via HTTP(S) or from S3 buckets. This is achieved via [`fsspec`](https://github.com/fsspec/filesystem_spec). For example, to read a MuData object from a remote server:
+::
+   import fsspec
+
+   fname = "https://github.com/gtca/h5xx-datasets/raw/main/datasets/minipbcite.h5mu?download="
+   with fsspec.open(fname) as f:
+      mdata = mudata.read_h5mu(f)
+
+
+A caching layer can be added in the following way:
+::
+   fname_cached = "filecache::" + fname
+   with fsspec.open(fname_cached, filecache={'cache_storage': '/tmp/'}):
+      mdata = mudata.read_h5mu(f)
+
+
+For more `fsspec` usage examples see [its documentation](https://filesystem-spec.readthedocs.io/).

--- a/mudata/_core/io.py
+++ b/mudata/_core/io.py
@@ -509,13 +509,14 @@ def _read_zarr_mod(g: zarr.Group, manager: MuDataFileManager = None, backed: boo
             d[k] = read_dataframe(g[k])
         elif k == "X":
             X = g["X"]
-            if isinstance(X, zarr.Group):
-                dtype = X["data"].dtype
-            elif hasattr(X, "dtype"):
-                dtype = X.dtype
-            else:
-                raise ValueError()
-            d["dtype"] = dtype
+            # No more dtype in anndata >=0.10
+            # if isinstance(X, zarr.Group):
+            #     dtype = X["data"].dtype
+            # elif hasattr(X, "dtype"):
+            #     dtype = X.dtype
+            # else:
+            #     raise ValueError()
+            # d["dtype"] = dtype
             if not backed:
                 d["X"] = read_elem(X)
         elif k != "raw":
@@ -550,13 +551,14 @@ def _read_h5mu_mod(
             d[k] = read_dataframe(g[k])
         elif k == "X":
             X = g["X"]
-            if isinstance(X, h5py.Group):
-                dtype = X["data"].dtype
-            elif hasattr(X, "dtype"):
-                dtype = X.dtype
-            else:
-                raise ValueError()
-            d["dtype"] = dtype
+            # No more dtype in anndata >=0.10
+            # if isinstance(X, h5py.Group):
+            #     dtype = X["data"].dtype
+            # elif hasattr(X, "dtype"):
+            #     dtype = X.dtype
+            # else:
+            #     raise ValueError()
+            # d["dtype"] = dtype
             if not backed:
                 d["X"] = read_elem(X)
         elif k != "raw":

--- a/mudata/_core/io.py
+++ b/mudata/_core/io.py
@@ -193,6 +193,8 @@ def write_zarr(
         # Restore top-level annotation
         if not mdata.is_view or not mdata.isbacked:
             mdata.update()
+    else:
+        raise TypeError("Expected MuData or AnnData object")
 
 
 def write_h5mu(filename: PathLike, mdata: MuData, **kwargs):
@@ -477,6 +479,13 @@ def read_zarr(store: Union[str, Path, MutableMapping, zarr.Group]):
             for m in gmods.keys():
                 ad = _read_zarr_mod(gmods[m], manager)
                 mods[m] = ad
+
+            mod_order = None
+            if "mod-order" in gmods.attrs:
+                mod_order = _read_attr(gmods.attrs, "mod-order")
+            if mod_order is not None and all([m in gmods for m in mod_order]):
+                mods = {k: mods[k] for k in mod_order}
+
             d[k] = mods
         else:  # Base case
             d[k] = read_elem(f[k])

--- a/mudata/_core/io.py
+++ b/mudata/_core/io.py
@@ -19,7 +19,7 @@ from anndata import AnnData
 from pathlib import Path
 from scipy import sparse
 
-from mudata import MuData
+from .mudata import ModDict, MuData
 from .file_backing import MuDataFileManager, AnnDataFileManager
 
 #
@@ -374,7 +374,7 @@ def read_h5mu(filename: PathLike, backed: Union[str, bool, None] = None):
             if k in ["obs", "var"]:
                 d[k] = read_dataframe(f[k])
             if k == "mod":
-                mods = {}
+                mods = ModDict()
                 gmods = f[k]
                 for m in gmods.keys():
                     ad = _read_h5mu_mod(gmods[m], manager, backed not in (None, False))

--- a/mudata/_core/io.py
+++ b/mudata/_core/io.py
@@ -34,13 +34,13 @@ def _write_h5mu(file: h5py.File, mdata: MuData, write_data=True, **kwargs):
     write_elem(
         file,
         "obs",
-        mdata.strings_to_categoricals(mdata._shrink_attr("obs", inplace=False)),
+        mdata.strings_to_categoricals(mdata._shrink_attr("obs", inplace=False).copy()),
         dataset_kwargs=kwargs,
     )
     write_elem(
         file,
         "var",
-        mdata.strings_to_categoricals(mdata._shrink_attr("var", inplace=False)),
+        mdata.strings_to_categoricals(mdata._shrink_attr("var", inplace=False).copy()),
         dataset_kwargs=kwargs,
     )
     write_elem(file, "obsm", dict(mdata.obsm), dataset_kwargs=kwargs)
@@ -127,13 +127,13 @@ def write_zarr(
         write_elem(
             file,
             "obs",
-            mdata.strings_to_categoricals(mdata._shrink_attr("obs", inplace=False)),
+            mdata.strings_to_categoricals(mdata._shrink_attr("obs", inplace=False).copy()),
             dataset_kwargs=kwargs,
         )
         write_elem(
             file,
             "var",
-            mdata.strings_to_categoricals(mdata._shrink_attr("var", inplace=False)),
+            mdata.strings_to_categoricals(mdata._shrink_attr("var", inplace=False).copy()),
             dataset_kwargs=kwargs,
         )
         write_elem(file, "obsm", dict(mdata.obsm), dataset_kwargs=kwargs)

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -304,6 +304,7 @@ class MuData:
         self.is_view = True
         self.file = mudata_ref.file
         self._axis = mudata_ref._axis
+        self.uns = mudata_ref.uns
 
         if mudata_ref.is_view:
             self._mudata_ref = mudata_ref._mudata_ref

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -28,7 +28,12 @@ from anndata._core.aligned_mapping import (
 from anndata._core.views import DataFrameView
 
 from .file_backing import MuDataFileManager
-from .utils import _make_index_unique, _restore_index, _maybe_coerce_to_boolean
+from .utils import (
+    _make_index_unique,
+    _restore_index,
+    _maybe_coerce_to_boolean,
+    _maybe_coerce_to_bool,
+)
 
 from .repr import *
 from .config import OPTIONS
@@ -643,14 +648,16 @@ class MuData:
                         axis=0,
                         sort=False,
                     )
-                    data_common = pd.concat(
-                        [
-                            _maybe_coerce_to_boolean(getattr(a, attr)[columns_common])
-                            for m, a in self.mod.items()
-                        ],
-                        join="outer",
-                        axis=0,
-                        sort=False,
+                    data_common = _maybe_coerce_to_bool(
+                        pd.concat(
+                            [
+                                _maybe_coerce_to_boolean(getattr(a, attr)[columns_common])
+                                for m, a in self.mod.items()
+                            ],
+                            join="outer",
+                            axis=0,
+                            sort=False,
+                        )
                     )
                     data_mod = data_mod.join(data_common, how="left", sort=False)
 
@@ -725,23 +732,27 @@ class MuData:
                 ]
 
                 # Here, attr_names are guaranteed to be unique and are safe to be used for joins
-                data_mod = pd.concat(
-                    dfs,
-                    join="outer",
-                    axis=axis,
-                    sort=False,
+                data_mod = _maybe_coerce_to_bool(
+                    pd.concat(
+                        dfs,
+                        join="outer",
+                        axis=axis,
+                        sort=False,
+                    )
                 )
 
-                data_common = pd.concat(
-                    [
-                        _maybe_coerce_to_boolean(
-                            _make_index_unique(getattr(a, attr)[columns_common])
-                        )
-                        for m, a in self.mod.items()
-                    ],
-                    join="outer",
-                    axis=0,
-                    sort=False,
+                data_common = _maybe_coerce_to_bool(
+                    pd.concat(
+                        [
+                            _maybe_coerce_to_boolean(
+                                _make_index_unique(getattr(a, attr)[columns_common])
+                            )
+                            for m, a in self.mod.items()
+                        ],
+                        join="outer",
+                        axis=0,
+                        sort=False,
+                    )
                 )
                 data_mod = data_mod.join(data_common, how="left", sort=False)
             else:

--- a/mudata/_core/mudata.py
+++ b/mudata/_core/mudata.py
@@ -1239,7 +1239,8 @@ class MuData:
         indent = "    " * nest_level
         backed_at = f" backed at {str(self.filename)!r}" if self.isbacked else ""
         view_of = "View of " if self.is_view else ""
-        descr = f"{view_of}MuData object with n_obs × n_vars = {n_obs} × {n_vars}{backed_at}"
+        maybe_axis = f" (axis={self.axis}) " if hasattr(self, "axis") and self.axis != 0 else ""
+        descr = f"{view_of}MuData object with n_obs × n_vars = {n_obs} × {n_vars}{maybe_axis}{backed_at}"
         for attr in ["obs", "var", "uns", "obsm", "varm", "obsp", "varp"]:
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 keys = list(getattr(self, attr).keys())
@@ -1268,7 +1269,7 @@ class MuData:
             mod_indent = "    " * (nest_level + 1)
             if isinstance(v, MuData):
                 descr += f"\n{mod_indent}{k}:\t" + v._gen_repr(
-                    n_obs, n_vars, extensive, nest_level + 1
+                    v.n_obs, v.n_vars, extensive, nest_level + 1
                 )
                 continue
             descr += f"\n{mod_indent}{k}:\t{v.n_obs} x {v.n_vars}"

--- a/mudata/_core/utils.py
+++ b/mudata/_core/utils.py
@@ -35,3 +35,24 @@ def _maybe_coerce_to_boolean(df: T) -> T:
             df = df.assign(**{col: df[col].astype("boolean")})
 
     return df
+
+
+def _maybe_coerce_to_bool(df: T) -> T:
+    if isinstance(df, pd.Series):
+        if isinstance(df.dtype, pd.BooleanDtype):
+            try:
+                return df.astype(bool)
+            except ValueError:
+                # cannot convert float NaN to bool
+                pass
+        return df
+
+    for col in df.columns:
+        if isinstance(df[col].dtype, pd.BooleanDtype):
+            try:
+                df = df.assign(**{col: df[col].astype(bool)})
+            except ValueError:
+                # cannot convert float NaN to bool
+                pass
+
+    return df

--- a/mudata/_core/utils.py
+++ b/mudata/_core/utils.py
@@ -44,7 +44,7 @@ def _maybe_coerce_to_bool(df: T) -> T:
                 return df.astype(bool)
             except ValueError:
                 # cannot convert float NaN to bool
-                pass
+                return df
         return df
 
     for col in df.columns:

--- a/tests/test_mod_order.py
+++ b/tests/test_mod_order.py
@@ -1,0 +1,57 @@
+import unittest
+import pytest
+
+import numpy as np
+import h5py
+import mudata
+from anndata import AnnData
+from mudata import MuData
+
+
+# Dimensions
+N = 100
+D1, D2, D3 = 10, 20, 30
+D = D1 + D2 + D3
+
+KEYS_ORDERED = ["c-first", "a-second", "b-third"]
+
+
+@pytest.fixture()
+def mdata():
+    mod1 = AnnData(np.arange(0, 100, 0.1).reshape(-1, D1))
+    mod1.obs_names = [f"obs{i}" for i in range(mod1.n_obs)]
+    mod1.var_names = [f"var{i}" for i in range(D1)]
+
+    mod2 = AnnData(np.arange(3101, 5101, 1).reshape(-1, D2))
+    mod2.obs_names = [f"obs{i}" for i in range(mod1.n_obs)]
+    mod2.var_names = [f"var{i}" for i in range(D2)]
+
+    mod3 = AnnData(np.arange(5101, 8101, 1).reshape(-1, D3))
+    mod3.obs_names = [f"obs{i}" for i in range(mod1.n_obs)]
+    mod3.var_names = [f"var{i}" for i in range(D3)]
+
+    # order of modalities should be preserved, namely
+    # c-first, then a-second, then b-third
+    mdata = MuData({"c-first": mod1, "a-second": mod2, "b-third": mod3})
+    yield mdata
+
+
+@pytest.mark.usefixtures("filepath_h5mu")
+class TestMuData:
+    def test_initial_order(self, mdata):
+        mods = list(mdata.mod.keys())
+        assert len(mods) == 3
+        assert mods == KEYS_ORDERED
+
+    def test_order_on_read(self, mdata, filepath_h5mu):
+        mdata.write_h5mu(filepath_h5mu)
+        mdata_read = mudata.read_h5mu(filepath_h5mu)
+
+        mods = list(mdata.mod.keys())
+        assert len(mods) == 3
+        assert mods == KEYS_ORDERED
+
+        # Test implementation (storage) as well
+        with h5py.File(filepath_h5mu, "r") as f:
+            assert "mod-order" in f["mod"].attrs
+            assert list(f["mod"].attrs["mod-order"]) == KEYS_ORDERED

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -1,0 +1,42 @@
+import unittest
+import pytest
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+from mudata import MuData
+
+
+# Dimensions
+N = 100
+D1, D2 = 10, 20
+D = D1 + D2
+
+
+@pytest.fixture()
+def mdata():
+    mod1 = AnnData(np.arange(0, 100, 0.1).reshape(-1, D1))
+    mod1.obs_names = [f"obs{i}" for i in range(mod1.n_obs)]
+    mod1.var_names = [f"var{i}" for i in range(D1)]
+
+    mod2 = AnnData(np.arange(3101, 5101, 1).reshape(-1, D2))
+    mod2.obs_names = mod1.obs_names.copy()
+    mod2.var_names = [f"var{i}" for i in range(D1, D)]
+
+    # bool + bool -> bool
+    mod1.var["assert-bool"] = True
+    mod2.var["assert-bool"] = False
+
+    # bool + NA -> boolean
+    mod1.var["assert-boolean-1"] = True
+    mod2.var["assert-boolean-2"] = False
+
+    mdata = MuData({"mod1": mod1, "mod2": mod2})
+    yield mdata
+
+
+class TestMuData:
+    def test_mdata_bool_boolean(self, mdata):
+        assert mdata.var["assert-bool"].dtype == bool
+        assert isinstance(mdata.var["mod1:assert-boolean-1"].dtype, pd.BooleanDtype)
+        assert isinstance(mdata.var["mod2:assert-boolean-2"].dtype, pd.BooleanDtype)

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,46 @@
+import unittest
+import pytest
+
+import numpy as np
+from anndata import AnnData
+from mudata import MuData
+
+
+# Dimensions
+N = 100
+D1, D2 = 10, 20
+D = D1 + D2
+
+
+@pytest.fixture()
+def mdata():
+    mod1 = AnnData(np.arange(0, 100, 0.1).reshape(-1, D1))
+    mod1.obs_names = [f"obs{i}" for i in range(mod1.n_obs)]
+    mod1.var_names = [f"var{i}" for i in range(D1)]
+
+    mod21 = AnnData(np.arange(3101, 5101, 1).reshape(-1, D2))
+    mod22 = AnnData(np.arange(3101, 5101, 1).reshape(-1, D2))
+    # Same obs_names and var_names
+    mod21.obs_names = mod1.obs_names.copy()
+    mod22.obs_names = mod1.obs_names.copy()
+    mod21.var_names = [f"var{i}" for i in range(D1, D)]
+    mod22.var_names = [f"var{i}" for i in range(D1, D)]
+    mod2 = MuData({"mod21": mod21, "mod22": mod22}, axis=-1)
+
+    mdata = MuData({"mod1": mod1, "mod2": mod2})
+    yield mdata
+
+
+class TestMuData:
+    def test_nested_mudata(self, mdata):
+        assert mdata.shape == (N, D)
+        assert mdata["mod1"].shape == (N, D1)
+        assert mdata["mod2"].shape == (N, D2)
+        assert mdata.axis == 0
+        assert mdata["mod2"].axis == -1
+
+    def test_mod_repr(self, mdata):
+        assert (
+            mdata.mod.__repr__()
+            == f"MuData\n├─ mod1 AnnData ({N} x {D1})\n└─ mod2 MuData [shared obs and var] ({N} × 20)\n   ├─ mod21 AnnData ({N} x {D2})\n   └─ mod22 AnnData ({N} x {D2})"
+        )

--- a/tests/test_view_copy.py
+++ b/tests/test_view_copy.py
@@ -32,6 +32,31 @@ class TestMuData:
         assert np.array_equal(mdata.obs.columns.values, mdata_copy.obs.columns.values)
         assert np.array_equal(mdata.var.columns.values, mdata_copy.var.columns.values)
 
+    def test_view_attributes(self, mdata):
+        mdata_copy = mdata.copy()
+        n, d = mdata.n_obs, mdata.n_var
+        # Populate attributes
+        mdata_copy.uns["uns_key"] = {"key": "value"}
+        mdata_copy.obs["obs_column"] = False
+        mdata_copy.var["var_column"] = False
+        mdata_copy.obsm["obsm_key"] = np.arange(n).reshape(-1, 1)
+        mdata_copy.varm["varm_key"] = np.arange(d).reshape(-1, 1)
+        mdata_copy.obsp["obsp_key"] = np.arange(n * n).reshape(n, n)
+        mdata_copy.varp["varp_key"] = np.arange(d * d).reshape(d, d)
+
+        view_n_obs = 7
+        mdata_view = mdata_copy[list(range(view_n_obs)), :]
+        assert mdata_view.shape == (view_n_obs, mdata.n_var)
+        assert len(mdata_view.mod) == len(mdata_copy.mod)
+        # AnnData/MuData interface
+        for attr in "obs", "var", "obsm", "varm", "obsp", "varp", "uns":
+            assert hasattr(mdata_view, attr)
+            assert list(getattr(mdata_view, attr).keys()) == list(getattr(mdata_copy, attr).keys())
+        # MuData-specific interface
+        for attr in "mod", "axis", "obsmap", "varmap":
+            assert hasattr(mdata_view, attr)
+        assert mdata_view.axis == mdata_copy.axis
+
     def test_view_copy(self, mdata):
         view_n_obs = 5
         mdata_view = mdata[list(range(view_n_obs)), :]


### PR DESCRIPTION
- [x] Fix nested `MuData` dimensions in `__repr__()`
- [x] Fix `.uns` contents for views (#52)
- [x] Use `mod-order` attribute in `read_zarr()` (#48)
- [x] Avoid sorting `.var_names` in the global index when modalities are added and `.var_names` are intersecting (#46)
- [x] Coerce nullable boolean arrays  to `bool` when there are no null values (https://github.com/scverse/muon/issues/111)