### PR TITLE
Add support for AnnData 0.10.0

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: "23.9.1"
     hooks:
       - id: black
         language_version: python3

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,10 @@ Release notes
 
    *
 
+v0.3.0
+
+This version adds support for `AnnData v0.10.0`.
+
 v0.2.2
 ------
 

--- a/mudata/_core/io.py
+++ b/mudata/_core/io.py
@@ -458,13 +458,6 @@ def _read_zarr_mod(g: zarr.Group, manager: MuDataFileManager = None, backed: boo
             d[k] = read_dataframe(g[k])
         elif k == "X":
             X = g["X"]
-            if isinstance(X, zarr.Group):
-                dtype = X["data"].dtype
-            elif hasattr(X, "dtype"):
-                dtype = X.dtype
-            else:
-                raise ValueError()
-            d["dtype"] = dtype
             if not backed:
                 d["X"] = read_elem(X)
         elif k != "raw":
@@ -499,13 +492,6 @@ def _read_h5mu_mod(
             d[k] = read_dataframe(g[k])
         elif k == "X":
             X = g["X"]
-            if isinstance(X, h5py.Group):
-                dtype = X["data"].dtype
-            elif hasattr(X, "dtype"):
-                dtype = X.dtype
-            else:
-                raise ValueError()
-            d["dtype"] = dtype
             if not backed:
                 d["X"] = read_elem(X)
         elif k != "raw":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,4 @@ exclude = [".github", "docs/build"]
 
 [tool.black]
 line-length = 100
-target-version = ['py37']
+target-version = ['py39']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Intended Audience :: Science/Research"
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 requires = [
     "numpy",
     "pandas",


### PR DESCRIPTION
Closes #59 
- Removes instances of `dtype` in `AnnData.__init__`
- Bumps required Python versions to 3.9 - 3.11
- Updates versions of GitHub Actions 