### PR TITLE
Fix writing to .h5mu after using `mudata.concat()`

### DIFF
--- a/src/mudata/_core/merge.py
+++ b/src/mudata/_core/merge.py
@@ -146,7 +146,7 @@ def concat(
     axis = mdatas[0].axis
 
     # Modalities intersection
-    common_mods = reduce(np.intersect1d, [np.array(list(m.mod.keys())) for m in mdatas])
+    common_mods = reduce(np.intersect1d, [np.array(list(m.mod.keys())).astype('object') for m in mdatas])
     assert len(common_mods) > 0, "There should be at least one common modality across all mdatas"
 
     # Concatenate all the modalities

--- a/src/mudata/_core/merge.py
+++ b/src/mudata/_core/merge.py
@@ -146,7 +146,9 @@ def concat(
     axis = mdatas[0].axis
 
     # Modalities intersection
-    common_mods = reduce(np.intersect1d, [np.array(list(m.mod.keys())).astype('object') for m in mdatas])
+    common_mods = reduce(
+        np.intersect1d, [np.array(list(m.mod.keys())).astype("object") for m in mdatas]
+    )
     assert len(common_mods) > 0, "There should be at least one common modality across all mdatas"
 
     # Concatenate all the modalities


### PR DESCRIPTION
Using `mudata.concat()` converts the keys in `ModDict` from generic Python strings to Numpy strings, causing an error to be thrown when using `MuData.write()`. The purpose of this pull request is to prevent this error by converting the keys in the `ModDict` of the returned `MuData` object back to generic Python strings, which can be written to .h5mu without issue.

Closes #73.