### PR TITLE
make obsmap and viewmap correct for views

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 24.10.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3

--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -315,8 +315,12 @@ class MuData:
 
         for attr, idx in (("obs", obsidx), ("var", varidx)):
             posmap = {}
+            size = getattr(self, attr).shape[0]
             for mod, mapping in getattr(mudata_ref, attr + "map").items():
-                posmap[mod] = mapping[idx].copy()
+                cposmap = np.zeros((size,), dtype=mapping.dtype)
+                cidx = mapping[idx] > 0
+                cposmap[cidx > 0] = np.arange(cidx.sum()) + 1
+                posmap[mod] = cposmap
             setattr(self, "_" + attr + "map", posmap)
 
         self.is_view = True


### PR DESCRIPTION
obsmap and viewmap in views should map to the modalities in the view, not the reference.