### PR TITLE
fix ordering of views of views

### DIFF
--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -268,6 +268,7 @@ class MuData:
 
     def _init_as_view(self, mudata_ref: "MuData", index):
         from anndata._core.index import _normalize_indices
+        from anndata._core.views import _resolve_idxs
 
         obsidx, varidx = _normalize_indices(index, mudata_ref.obs.index, mudata_ref.var.index)
 
@@ -307,9 +308,13 @@ class MuData:
                         cvaridx = slice(None)
             if a.is_view:
                 if isinstance(a, MuData):
-                    self.mod[m] = a._mudata_ref[cobsidx, cvaridx]
+                    self.mod[m] = a._mudata_ref[
+                        _resolve_idxs((a._oidx, a._vidx), (cobsidx, cvaridx), a._mudata_ref)
+                    ]
                 else:
-                    self.mod[m] = a._adata_ref[cobsidx, cvaridx]
+                    self.mod[m] = a._adata_ref[
+                        _resolve_idxs((a._oidx, a._vidx), (cobsidx, cvaridx), a._adata_ref)
+                    ]
             else:
                 self.mod[m] = a[cobsidx, cvaridx]
 
@@ -334,6 +339,8 @@ class MuData:
         self.file = mudata_ref.file
         self._axis = mudata_ref._axis
         self._uns = mudata_ref._uns
+        self._oidx = obsidx
+        self._vidx = varidx
 
         if mudata_ref.is_view:
             self._mudata_ref = mudata_ref._mudata_ref

--- a/tests/test_view_copy.py
+++ b/tests/test_view_copy.py
@@ -88,6 +88,18 @@ class TestMuData:
         assert mdata_view_view.is_view
         assert mdata_view_view.n_obs == view_view_n_obs
 
+        for modname, mod in mdata_view_view.mod.items():
+            ref_obsmap = mdata_view.obsmap[modname][:view_view_n_obs]
+            ref_obsmap = ref_obsmap[ref_obsmap > 0] - 1
+            assert (mod.obs_names == mdata_view[modname].obs_names[ref_obsmap]).all()
+            assert (mod.var_names == mdata_view[modname].var_names).all()
+
+        # test reordering
+        mdata_view_view = mdata_view[:, :]
+        for modname, mod in mdata_view_view.mod.items():
+            assert (mod.obs_names == mdata_view[modname].obs_names).all()
+            assert (mod.var_names == mdata_view[modname].var_names).all()
+
     def test_backed_copy(self, mdata, filepath_h5mu, filepath2_h5mu):
         mdata.write(filepath_h5mu)
         mdata_b = mudata.read_h5mu(filepath_h5mu, backed="r")


### PR DESCRIPTION
Previously, taking a view of a view would mix up the rows/columns due to using incorrect maps.