### PR TITLE
basic support for AnnData accessors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-test = [ "coverage>=7.10", "mudata[io]", "pytest" ]
+test = [ "coverage>=7.10", "mudata[io]", "packaging", "pytest" ]
 doc = [
   "docutils>=0.8,!=0.18.*,!=0.19.*",
   "ipykernel",

--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -533,8 +533,30 @@ class MuData:
     def __getitem__(self, index) -> AnnData | MuData:
         if isinstance(index, str):
             return self._mod[index]
-        else:
-            return MuData(self, as_view=True, index=index)
+
+        with suppress(ImportError):
+            from anndata.acc import AdRef
+
+            if isinstance(index, AdRef):
+                try:
+                    return index.acc.get(self, index.idx)
+                except KeyError as e:
+                    if index.acc.dim in ("obs", "var"):
+                        for modname, mod in self._mod.items():
+                            try:
+                                index.acc.get(mod, index.idx)
+                            except KeyError:
+                                pass
+                            else:
+                                raise KeyError(
+                                    f"There is no key {index.idx} in MuData .{index.acc.dim} but there is one in {modname} .{index.acc.dim}. Consider running `pull_{index.acc.dim}()` to update global .{index.acc.dim}."
+                                ) from e
+                        raise KeyError(
+                            f"There is no key {index.idx} in MuData .{index.acc.dim} or in .{index.acc.dim} of any modalities."
+                        ) from e
+                    else:
+                        raise
+        return MuData(self, as_view=True, index=index)
 
     @property
     def mod(self) -> Mapping[str, AnnData | MuData]:

--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -543,19 +543,11 @@ class MuData:
                 except KeyError as e:
                     if index.acc.dim in ("obs", "var"):
                         for modname, mod in self._mod.items():
-                            try:
-                                index.acc.get(mod, index.idx)
-                            except KeyError:
-                                pass
-                            else:
+                            if index in mod:
                                 raise KeyError(
                                     f"There is no key {index.idx} in MuData .{index.acc.dim} but there is one in {modname} .{index.acc.dim}. Consider running `pull_{index.acc.dim}()` to update global .{index.acc.dim}."
                                 ) from e
-                        raise KeyError(
-                            f"There is no key {index.idx} in MuData .{index.acc.dim} or in .{index.acc.dim} of any modalities."
-                        ) from e
-                    else:
-                        raise
+                    raise
         return MuData(self, as_view=True, index=index)
 
     @property

--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -550,6 +550,16 @@ class MuData:
                     raise
         return MuData(self, as_view=True, index=index)
 
+    def __contains__(self, key) -> bool:
+        if isinstance(key, str):
+            return key in self._mod
+        with suppress(ImportError):
+            from anndata.acc import AdRef, MapAcc, RefAcc
+
+            if isinstance(key, AdRef | RefAcc | MapAcc):
+                return AnnData.__contains__(self, key)
+        raise TypeError(f"Unexpected key {key!r}.")
+
     @property
     def mod(self) -> Mapping[str, AnnData | MuData]:
         """Dictionary of modalities."""

--- a/tests/test_obs_var.py
+++ b/tests/test_obs_var.py
@@ -154,7 +154,7 @@ def test_names_make_unique(mdata: md.MuData):
 )
 def test_accessors(mdata: md.MuData):
     assert (mdata[ad.acc.A.obs["arange"]] == mdata.obs["arange"]).all()
-    with pytest.raises(KeyError, match="any modalities"):
+    with pytest.raises(KeyError, match="test"):
         mdata[ad.acc.A.var["test"]]
     with pytest.raises(KeyError, match="there is one in"):
         mdata[ad.acc.A.var["assert-bool"]]

--- a/tests/test_obs_var.py
+++ b/tests/test_obs_var.py
@@ -153,6 +153,7 @@ def test_names_make_unique(mdata: md.MuData):
     Version(ad.__version__) < Version("0.13dev0"), reason="anndata version too old, no accessor support"
 )
 def test_accessors(mdata: md.MuData):
+    assert ad.acc.A.obs["arange"] in mdata
     assert (mdata[ad.acc.A.obs["arange"]] == mdata.obs["arange"]).all()
     with pytest.raises(KeyError, match="test"):
         mdata[ad.acc.A.var["test"]]

--- a/tests/test_obs_var.py
+++ b/tests/test_obs_var.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
+import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import Version
 
 import mudata as md
 
@@ -145,3 +147,14 @@ def test_names_make_unique(mdata: md.MuData):
 
     with pytest.raises(TypeError, match="axis="):
         getattr(mdata, f"{attr}_names_make_unique")()
+
+
+@pytest.mark.skipif(
+    Version(ad.__version__) < Version("0.13dev0"), reason="anndata version too old, no accessor support"
+)
+def test_accessors(mdata: md.MuData):
+    assert (mdata[ad.acc.A.obs["arange"]] == mdata.obs["arange"]).all()
+    with pytest.raises(KeyError, match="any modalities"):
+        mdata[ad.acc.A.var["test"]]
+    with pytest.raises(KeyError, match="there is one in"):
+        mdata[ad.acc.A.var["assert-bool"]]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -146,6 +146,9 @@ def test_update_simple(mdata: MuData, axis: Axis):
     for mod in mdata.mod.keys():
         assert mdata.obsmap[mod].dtype.kind == "u"
         assert mdata.varmap[mod].dtype.kind == "u"
+        assert mod in mdata
+    with pytest.raises(TypeError):
+        1 in mdata  # noqa: B015
 
     # names along non-axis are concatenated
     assert mdata.shape[1 - axis] == sum(mod.shape[1 - axis] for mod in mdata.mod.values())


### PR DESCRIPTION
The main point of this is to still be able to pass MuData objects to scanpy's plotting functions. This is currently possible due to MuData's implementation of `obs_vector` and `var_vector`, but if I understand the scanpy changes correctly (e.g. [here](https://github.com/scverse/scanpy/blob/ba83d7756617b02483c728dec8bc3f8ebeed3569/src/scanpy/plotting/_utils.py#L1161)) this will stop working as soon as anndata 0.13 is released.

The logic is based on the current `_attr_vector` implementation, which will go away at some point when `obs_vector` and `var_vector` are removed.

I'd appreciate some feedback on where else scanpy has switched to accessors. For example, it is [currently possible](https://muon-tutorials.readthedocs.io/en/latest/single-cell-rna-atac/pbmc10k/3-Multimodal-Omics-Data-Integration.html#Perform-integration) to run `sc.pp.neighbors` and `sc.tl.umap` on a MuData object. Have these also switched to using accessors to access `.obsm`/`obsp`?