### PR TITLE
test: make sure no warnings happen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,12 @@ lint.pydocstyle.convention = "numpy"
 addopts = [
   "--import-mode=importlib", # allow using test files with same name
 ]
+filterwarnings = [
+  "error",
+  "ignore:Writing zarr v2 data will no longer be the default",
+  "ignore:Only some AnnData objects have `.raw` attribute",
+  "ignore::scipy.sparse.SparseEfficiencyWarning",
+]
 strict = true
 testpaths = [ "tests" ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ addopts = [
 filterwarnings = [
   "error",
   "ignore:Writing zarr v2 data will no longer be the default",
-  "ignore:Only some AnnData objects have `.raw` attribute",
   "ignore::scipy.sparse.SparseEfficiencyWarning",
 ]
 strict = true

--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -1405,7 +1405,7 @@ class MuData:
 
             # prepend modality prefix to column names if requested via arguments and there are no skipped modalities with
             # the same column name (prefixing those columns may cause problems with future pulls or pushes)
-            mod_df.rename(
+            mod_df = mod_df.rename(
                 columns={
                     col.derived_name: col.name
                     for col in modcols
@@ -1420,8 +1420,7 @@ class MuData:
                         )
                         and derived_name_count[col.derived_name] == col.count
                     )
-                },
-                inplace=True,
+                }
             )
 
             # reorder modality DF to conform to global order

--- a/src/mudata/_core/mudata.py
+++ b/src/mudata/_core/mudata.py
@@ -1405,7 +1405,7 @@ class MuData:
 
             # prepend modality prefix to column names if requested via arguments and there are no skipped modalities with
             # the same column name (prefixing those columns may cause problems with future pulls or pushes)
-            mod_df = mod_df.rename(
+            mod_df.rename(
                 columns={
                     col.derived_name: col.name
                     for col in modcols
@@ -1420,7 +1420,8 @@ class MuData:
                         )
                         and derived_name_count[col.derived_name] == col.count
                     )
-                }
+                },
+                inplace=True,
             )
 
             # reorder modality DF to conform to global order

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import fields
-from importlib import resources
+from importlib import metadata, resources
 from urllib.request import urlopen
 
 import anndata as ad
@@ -13,7 +13,7 @@ from packaging.version import Version
 
 import mudata as md
 
-if Version(ad.__version__) < Version("0.13dev0"):
+if Version(metadata.version("anndata")) < Version("0.13dev0"):
     pytest.skip("anndata version too old, no accessor support", allow_module_level=True)
 
 from mudata.acc import A

--- a/tests/test_from_to.py
+++ b/tests/test_from_to.py
@@ -25,6 +25,6 @@ def test_from_anndata(rng: np.random.Generator):
     adata.var["feature_types"] = rng.choice(["mod1", "mod2", "mod3"], size=adata.n_vars)
     mdata = MuData(adata)
     assert mdata.n_mod == 3
-    assert sorted(mdata.mod_names) == ["mod1", "mod2", "mod3"]
+    assert sorted(mdata.mod.keys()) == ["mod1", "mod2", "mod3"]
     for m, mod in mdata.mod.items():
         assert (mod.var_names == adata.var_names[adata.var.feature_types == m]).all()

--- a/tests/test_from_to.py
+++ b/tests/test_from_to.py
@@ -1,9 +1,11 @@
 import numpy as np
+import pytest
 from anndata import AnnData
 
 from mudata import MuData, to_mudata
 
 
+@pytest.mark.filterwarnings("ignore:Only some AnnData objects have `.raw` attribute")
 def test_to_anndata_simple(mdata: MuData):
     adata = mdata.to_anndata()
     assert isinstance(adata, AnnData)
@@ -12,6 +14,7 @@ def test_to_anndata_simple(mdata: MuData):
     assert np.array_equal(adata.obs["arange"], np.arange(mdata.n_obs))
 
 
+@pytest.mark.filterwarnings("ignore:Only some AnnData objects have `.raw` attribute")
 def test_to_mudata_simple(mdata: MuData):
     adata = mdata.to_anndata()
     mdata_from_adata = to_mudata(adata, axis=0, by="feature_type")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -108,7 +108,7 @@ def test_h5mu_backed_to_memory(mdata: md.MuData, filepath_h5mu: str | Path):
     mdata_.filename = None
     assert not mdata_.isbacked
 
-    for modname in mdata.mod_names:
+    for modname in mdata.mod:
         assert isinstance(mdata_.mod[modname].X, np.ndarray) or issparse(mdata_.mod[modname].X)
         assert (mdata_.mod[modname].X == mdata.mod[modname].X).all()
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -14,7 +14,7 @@ def test_merge(mdata_nouniqueobs: md.MuData, filepath_h5mu: str | Path, roundtri
         mdata_.write_h5mu(filepath_h5mu)
         mdata_ = md.read_h5mu(filepath_h5mu)
     assert list(mdata_.mod.keys()) == ["mod1", "mod2"]
-    for m in mdata_.mod_names:
+    for m in mdata_.mod:
         assert mdata_.mod[m].shape == mdata_nouniqueobs.mod[m].shape
     assert np.array_equal(mdata_.mod["mod1"].X, mdata_nouniqueobs.mod["mod1"].X)
     assert np.array_equal(mdata_.mod["mod2"].X, mdata_nouniqueobs.mod["mod2"].X)

--- a/tests/test_obs_var.py
+++ b/tests/test_obs_var.py
@@ -42,6 +42,7 @@ def test_set_obs_names(mdata: md.MuData):  # https://github.com/scverse/mudata/i
         mdata.obs = pd.DataFrame()
 
 
+@pytest.mark.filterwarnings("ignore:.*obs_vector.*deprecated:FutureWarning")
 def test_obs_vector(mdata: md.MuData):
     assert (mdata.obs["arange"] == mdata.obs_vector("arange")).all()
     with pytest.raises(KeyError, match="There is no key foo in MuData"):
@@ -97,6 +98,7 @@ def test_set_var_names(mdata: md.MuData):  # https://github.com/scverse/mudata/i
         mdata.var = pd.DataFrame()
 
 
+@pytest.mark.filterwarnings("ignore:.*var_vector.*deprecated:FutureWarning")
 def test_var_vector(rng: np.random.Generator, mdata: md.MuData):
     mdata.var["test"] = rng.uniform(size=mdata.n_vars)
     assert (mdata.var["test"] == mdata.var_vector("test")).all()
@@ -117,7 +119,7 @@ def test_names_make_unique(mdata: md.MuData):
     namesattr = f"{oattr}_names"
     namesfun = getattr(mdata, f"{oattr}_names_make_unique")
 
-    mods = mdata.mod_names
+    mods = list(mdata.mod.keys())
     names = getattr(mdata.mod[mods[0]], namesattr)
     nameslist = names.to_list()
     nameslist[1] = nameslist[0]

--- a/tests/test_pull_push.py
+++ b/tests/test_pull_push.py
@@ -91,7 +91,8 @@ def mdata(
             idx = (mod2_which, slice(None)) if axis == 0 else (slice(None), mod2_which)
             mods["mod2"] = mods["mod2"][idx].copy()
 
-    return MuData(mods, axis=axis)
+    with pytest.warns(UserWarning, match=r"(obs|var)_names are not unique"):
+        return MuData(mods, axis=axis)
 
 
 @pytest.fixture

--- a/tests/test_pull_push.py
+++ b/tests/test_pull_push.py
@@ -1,10 +1,13 @@
 from collections.abc import Callable, Generator
+from contextlib import nullcontext
+from importlib import metadata
 from typing import Literal
 
 import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
+from packaging.version import Version
 
 from mudata import MuData
 
@@ -12,10 +15,13 @@ type Axis = Literal[0, 1]
 type AxisAttr = Literal["obs", "var"]
 
 
+PANDAS_VERSION = Version(metadata.version("pandas"))
+
+
 @pytest.fixture(autouse=True)
 def _pandas_cow() -> Generator[None]:
     """Make sure that we test pandas 3’s copy-on-write behavior."""
-    with pd.option_context("mode.copy_on_write", True):
+    with pd.option_context("mode.copy_on_write", True) if PANDAS_VERSION.major < 3 else nullcontext():
         yield
 
 

--- a/tests/test_pull_push.py
+++ b/tests/test_pull_push.py
@@ -47,8 +47,6 @@ def mdata(
         i1 = i + 1
         m = f"mod{i1}"
         mods[m] = AnnData(X=rng.normal(size=1000 * i1).reshape(-1, 10 * i1))
-        mods[m].obs_names = f"{m}-" + mods[m].obs_names
-        mods[m].var_names = f"{m}-" + mods[m].var_names
         mods[m].obs["mod"] = m
         mods[m].var["mod"] = m
         mods[m].obs["assert-bool"] = True

--- a/tests/test_pull_push.py
+++ b/tests/test_pull_push.py
@@ -47,6 +47,8 @@ def mdata(
         i1 = i + 1
         m = f"mod{i1}"
         mods[m] = AnnData(X=rng.normal(size=1000 * i1).reshape(-1, 10 * i1))
+        mods[m].obs_names = f"{m}-" + mods[m].obs_names
+        mods[m].var_names = f"{m}-" + mods[m].var_names
         mods[m].obs["mod"] = m
         mods[m].var["mod"] = m
         mods[m].obs["assert-bool"] = True

--- a/tests/test_pull_push.py
+++ b/tests/test_pull_push.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Literal
 
 import numpy as np
@@ -10,6 +10,13 @@ from mudata import MuData
 
 type Axis = Literal[0, 1]
 type AxisAttr = Literal["obs", "var"]
+
+
+@pytest.fixture(autouse=True)
+def _pandas_cow() -> Generator[None]:
+    """Make sure that we test pandas 3’s copy-on-write behavior."""
+    with pd.option_context("mode.copy_on_write", True):
+        yield
 
 
 @pytest.fixture(params=(0, 1))

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -12,10 +12,10 @@ def test_repr(mdata: md.MuData):
     assert rep[1].lstrip().startswith("obs:")
 
     for col in mdata.obs.columns:
-        if not any(col.startswith(f"{mod}:") for mod in mdata.mod_names):
+        if not any(col.startswith(f"{mod}:") for mod in mdata.mod):
             assert col in rep[1]
     for col in mdata.var.columns:
-        if not any(col.startswith(f"{mod}:") for mod in mdata.mod_names):
+        if not any(col.startswith(f"{mod}:") for mod in mdata.mod):
             assert col in rep[2]
 
     assert rep[2].strip() == f"{mdata.n_mod} modalities"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -13,6 +13,12 @@ from mudata import MuData
 type Axis = Literal[0, 1]
 
 
+pytestmark = [
+    pytest.mark.filterwarnings(r"ignore:(obs|var)_names.*not unique"),
+    pytest.mark.filterwarnings(r"ignore:Duplicated (obs|var)_names should not be present in different modalities"),
+]
+
+
 @pytest.fixture(params=(0, 1))
 def axis(request: pytest.FixtureRequest) -> Axis:
     return request.param
@@ -60,30 +66,29 @@ def modalities(
         if across != "intersecting":
             raise NotImplementedError("Tests for non-intersecting obs_names are not implemented")
 
-    if mod:
-        if mod == "duplicated":
-            obsnames2 = mods["mod2"].obs_names.to_numpy()
-            obsnames3 = mods["mod3"].obs_names.to_numpy()
-            varnames2 = mods["mod2"].var_names.to_numpy()
-            varnames3 = mods["mod3"].var_names.to_numpy()
-            obsnames2[0] = obsnames2[1] = obsnames3[1] = "testobs"
-            varnames2[0] = varnames2[1] = varnames3[1] = "testvar"
-            mods["mod2"].obs_names = obsnames2
-            mods["mod3"].obs_names = obsnames3
-            mods["mod2"].var_names = varnames2
-            mods["mod3"].var_names = varnames3
-        elif mod == "extreme_duplicated":  # integer overflow: https://github.com/scverse/mudata/issues/107
-            obsnames2 = mods["mod2"].obs_names.to_numpy()
-            varnames2 = mods["mod2"].var_names.to_numpy()
-            obsnames2[:-1] = obsnames2[0] = "testobs"
-            varnames2[:-1] = varnames2[0] = "testvar"
-            mods["mod2"].obs_names = obsnames2
-            mods["mod2"].var_names = varnames2
+    if mod == "duplicated":
+        obsnames2 = mods["mod2"].obs_names.to_numpy()
+        obsnames3 = mods["mod3"].obs_names.to_numpy()
+        varnames2 = mods["mod2"].var_names.to_numpy()
+        varnames3 = mods["mod3"].var_names.to_numpy()
+        obsnames2[0] = obsnames2[1] = obsnames3[1] = "testobs"
+        varnames2[0] = varnames2[1] = varnames3[1] = "testvar"
+        mods["mod2"].obs_names = obsnames2
+        mods["mod3"].obs_names = obsnames3
+        mods["mod2"].var_names = varnames2
+        mods["mod3"].var_names = varnames3
+    elif mod == "extreme_duplicated":  # integer overflow: https://github.com/scverse/mudata/issues/107
+        obsnames2 = mods["mod2"].obs_names.to_numpy()
+        varnames2 = mods["mod2"].var_names.to_numpy()
+        obsnames2[:-1] = obsnames2[0] = "testobs"
+        varnames2[:-1] = varnames2[0] = "testvar"
+        mods["mod2"].obs_names = obsnames2
+        mods["mod2"].var_names = varnames2
 
     return mods
 
 
-def add_mdata_global_columns(md: MuData, rng: np.random.Generator):
+def add_mdata_global_columns(md: MuData, rng: np.random.Generator) -> MuData:
     md.obs["batch"] = rng.choice(["a", "b", "c"], size=md.shape[0])
     md.var["batch"] = rng.choice(["d", "e", "f"], size=md.shape[1])
 
@@ -130,7 +135,7 @@ def assert_dtypes(df: pd.DataFrame):
     assert pd.api.types.is_integer_dtype(df["dtype-int"])
     assert pd.api.types.is_float_dtype(df["dtype-float"])
     assert pd.api.types.is_bool_dtype(df["dtype-bool"])
-    assert pd.api.types.is_categorical_dtype(df["dtype-categorical"])
+    assert isinstance(df["dtype-categorical"].array, pd.Categorical)
     assert pd.api.types.is_string_dtype(df["batch"]) or df["batch"].dtype == object
 
 

--- a/tests/test_view_copy.py
+++ b/tests/test_view_copy.py
@@ -203,6 +203,7 @@ def _test_view_after_setattr(mdata: md.MuData, mdata_ref: md.MuData, skip: Seque
                 assert (v.columns == mdata_ref.varm[k].columns).all()
 
 
+@pytest.mark.filterwarnings("ignore::anndata.ImplicitModificationWarning")
 def test_view_setattr(mdata_with_obsp: md.MuData):
     view = mdata_with_obsp[:42, :]
     view.obs_names = [f"foo_{i}" for i in range(len(view))]


### PR DESCRIPTION
I saw the `ad.__version__` and didn’t realize at the time that it’s already deprecated.

Remembering that made me realize that we’re not testing for warnings here. This PR introduces that.